### PR TITLE
change url for snap

### DIFF
--- a/src/utils/data/urls.ts
+++ b/src/utils/data/urls.ts
@@ -1,4 +1,4 @@
-const SNAP = 'https://www.snapwa.org/rental-assistance-faqs/';
+const SNAP = 'https://www.snapwa.org/';
 
 const CC = 'https://www.cceasternwa.org/';
 


### PR DESCRIPTION
Change url for SNAP application, current link will likely be changed by SNAP on the 24th.

This link will be good indefinitely.